### PR TITLE
PLAYWEB-175 defaulting futura-heavy to be antialiased

### DIFF
--- a/src/fonts.css
+++ b/src/fonts.css
@@ -69,6 +69,7 @@
                roboto, noto,
                'segoe ui', arial,
                sans-serif;
+  -webkit-font-smoothing: antialiased;
 }
 
 .futura-book {


### PR DESCRIPTION
limit (per Andrew) is anything 16 (f6) and under should NOT be antialiased and instead should get an override of `-webkit-font-smoothing: initial;`